### PR TITLE
Enable dynamic retrieval of scope values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.12</version>

--- a/src/main/java/org/zalando/stups/tokens/AbstractJsonFileBackedCredentialsProvider.java
+++ b/src/main/java/org/zalando/stups/tokens/AbstractJsonFileBackedCredentialsProvider.java
@@ -15,14 +15,14 @@
  */
 package org.zalando.stups.tokens;
 
-import java.io.File;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.File;
 
 public abstract class AbstractJsonFileBackedCredentialsProvider {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-    private final FileSupplier fileSupplier;
+    private final Supplier<File> fileSupplier;
 
     public AbstractJsonFileBackedCredentialsProvider(final String filename) {
         this.fileSupplier = new FileSupplier(filename);

--- a/src/main/java/org/zalando/stups/tokens/AccessTokenConfiguration.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokenConfiguration.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,59 +15,29 @@
  */
 package org.zalando.stups.tokens;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 public class AccessTokenConfiguration {
+
+    @FunctionalInterface
+    interface ScopeConfiguration {
+        Set<String> getScopes();
+    }
+
     private final Object tokenId;
-    private final AccessTokensBuilder accessTokensBuilder;
 
-    private final Set<Object> scopes = new HashSet<Object>();
+    private final ScopeConfiguration scopeConfiguration;
 
-    private boolean locked = false;
-
-    AccessTokenConfiguration(final Object tokenId, final AccessTokensBuilder accessTokensBuilder) {
+    AccessTokenConfiguration(final Object tokenId, final ScopeConfiguration scopeConfiguration) {
         this.tokenId = tokenId;
-        this.accessTokensBuilder = accessTokensBuilder;
-    }
-    private void checkLock() {
-        if (locked) {
-            throw new IllegalStateException("scope configuration already done");
-        }
-    }
-
-    private void checkNotNull(final String name, final Object obj) {
-        if (obj == null) {
-            throw new IllegalArgumentException(name + " must not be null");
-        }
-    }
-
-    public AccessTokenConfiguration addScope(final Object scope) {
-        checkLock();
-        checkNotNull("scope", scope);
-        scopes.add(scope);
-        return this;
-    }
-
-    public AccessTokenConfiguration addScopes(final Collection<Object> scopes) {
-        checkLock();
-        checkNotNull("scopes", scopes);
-        this.scopes.addAll(scopes);
-        return this;
+        this.scopeConfiguration = scopeConfiguration;
     }
 
     Object getTokenId() {
         return tokenId;
     }
 
-    Set<Object> getScopes() {
-        return Collections.unmodifiableSet(scopes);
-    }
-
-    public AccessTokensBuilder done() {
-        locked = true;
-        return accessTokensBuilder;
+    Set<String> getScopes() {
+        return scopeConfiguration.getScopes();
     }
 }

--- a/src/main/java/org/zalando/stups/tokens/AccessTokenConfiguration.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokenConfiguration.java
@@ -21,7 +21,7 @@ public class AccessTokenConfiguration {
 
     @FunctionalInterface
     interface ScopeConfiguration {
-        Set<String> getScopes();
+        Set<Object> getScopes();
     }
 
     private final Object tokenId;
@@ -37,7 +37,7 @@ public class AccessTokenConfiguration {
         return tokenId;
     }
 
-    Set<String> getScopes() {
+    Set<Object> getScopes() {
         return scopeConfiguration.getScopes();
     }
 }

--- a/src/main/java/org/zalando/stups/tokens/AccessTokenConfiguration.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokenConfiguration.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/zalando/stups/tokens/AccessTokenConfigurationBuilder.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokenConfigurationBuilder.java
@@ -18,7 +18,6 @@ package org.zalando.stups.tokens;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.function.Supplier;
 
 import static java.util.Collections.singletonList;
 
@@ -40,7 +39,12 @@ public class AccessTokenConfigurationBuilder {
     }
 
     public ScopeConfigurationBuilder.Dynamic addScope(final Supplier<Object> scopeSupplier) {
-        return new ScopeConfigurationBuilder.Dynamic(this, () -> new HashSet<>(singletonList(scopeSupplier.get())));
+        return new ScopeConfigurationBuilder.Dynamic(this, new Supplier<Set<Object>>() {
+            @Override
+            public Set<Object> get() {
+                return new HashSet<>(singletonList(scopeSupplier.get()));
+            }
+        });
     }
 
     public ScopeConfigurationBuilder.Dynamic addScopes(final Supplier<Set<Object>> scopeSupplier) {

--- a/src/main/java/org/zalando/stups/tokens/AccessTokenConfigurationBuilder.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokenConfigurationBuilder.java
@@ -31,19 +31,19 @@ public class AccessTokenConfigurationBuilder {
         this.accessTokensBuilder = accessTokensBuilder;
     }
 
-    public ScopeConfigurationBuilder.Static addScope(final String scope) {
+    public ScopeConfigurationBuilder.Static addScope(final Object scope) {
         return new ScopeConfigurationBuilder.Static(this, new HashSet<>(singletonList(scope)));
     }
 
-    public ScopeConfigurationBuilder.Static addScopes(final Collection<String> scopes) {
+    public ScopeConfigurationBuilder.Static addScopes(final Collection<Object> scopes) {
         return new ScopeConfigurationBuilder.Static(this, new HashSet<>(scopes));
     }
 
-    public ScopeConfigurationBuilder.Dynamic addScope(final Supplier<String> scopeSupplier) {
+    public ScopeConfigurationBuilder.Dynamic addScope(final Supplier<Object> scopeSupplier) {
         return new ScopeConfigurationBuilder.Dynamic(this, () -> new HashSet<>(singletonList(scopeSupplier.get())));
     }
 
-    public ScopeConfigurationBuilder.Dynamic addScopes(final Supplier<Set<String>> scopeSupplier) {
+    public ScopeConfigurationBuilder.Dynamic addScopes(final Supplier<Set<Object>> scopeSupplier) {
         return new ScopeConfigurationBuilder.Dynamic(this, scopeSupplier);
     }
 

--- a/src/main/java/org/zalando/stups/tokens/AccessTokenConfigurationBuilder.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokenConfigurationBuilder.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/zalando/stups/tokens/AccessTokenConfigurationBuilder.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokenConfigurationBuilder.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zalando.stups.tokens;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import static java.util.Collections.singletonList;
+
+public class AccessTokenConfigurationBuilder {
+    private final Object tokenId;
+    private final AccessTokensBuilder accessTokensBuilder;
+
+    AccessTokenConfigurationBuilder(final Object tokenId, final AccessTokensBuilder accessTokensBuilder) {
+        this.tokenId = tokenId;
+        this.accessTokensBuilder = accessTokensBuilder;
+    }
+
+    public ScopeConfigurationBuilder.Static addScope(final String scope) {
+        return new ScopeConfigurationBuilder.Static(this, new HashSet<>(singletonList(scope)));
+    }
+
+    public ScopeConfigurationBuilder.Static addScopes(final Collection<String> scopes) {
+        return new ScopeConfigurationBuilder.Static(this, new HashSet<>(scopes));
+    }
+
+    public ScopeConfigurationBuilder.Dynamic addScope(final Supplier<String> scopeSupplier) {
+        return new ScopeConfigurationBuilder.Dynamic(this, () -> new HashSet<>(singletonList(scopeSupplier.get())));
+    }
+
+    public ScopeConfigurationBuilder.Dynamic addScopes(final Supplier<Set<String>> scopeSupplier) {
+        return new ScopeConfigurationBuilder.Dynamic(this, scopeSupplier);
+    }
+
+    AccessTokensBuilder build(AccessTokenConfiguration.ScopeConfiguration scopeConfiguration) {
+        accessTokensBuilder.addAccessTokenConfigurations(new AccessTokenConfiguration(tokenId, scopeConfiguration));
+        return accessTokensBuilder;
+    }
+}

--- a/src/main/java/org/zalando/stups/tokens/AccessTokenRefresher.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokenRefresher.java
@@ -42,12 +42,13 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+
+import static java.util.stream.Collectors.joining;
 
 class AccessTokenRefresher implements AccessTokens, Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(AccessTokenRefresher.class);
@@ -148,16 +149,8 @@ class AccessTokenRefresher implements AccessTokens, Runnable {
         }
     }
 
-    private static String joinScopes(final Collection<Object> scopes) {
-        final Iterator<Object> iter = scopes.iterator();
-
-        final StringBuilder scope = new StringBuilder(iter.next().toString());
-        while (iter.hasNext()) {
-            scope.append(' ');
-            scope.append(iter.next().toString());
-        }
-
-        return scope.toString();
+    private static String joinScopes(final Collection<String> scopes) {
+        return scopes.stream().collect(joining(" "));
     }
 
     private AccessToken createToken(final AccessTokenConfiguration tokenConfig) {

--- a/src/main/java/org/zalando/stups/tokens/AccessTokenRefresher.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokenRefresher.java
@@ -149,8 +149,8 @@ class AccessTokenRefresher implements AccessTokens, Runnable {
         }
     }
 
-    private static String joinScopes(final Collection<String> scopes) {
-        return scopes.stream().collect(joining(" "));
+    private static String joinScopes(final Collection<Object> scopes) {
+        return scopes.stream().map(Object::toString).collect(joining(" "));
     }
 
     private AccessToken createToken(final AccessTokenConfiguration tokenConfig) {

--- a/src/main/java/org/zalando/stups/tokens/AccessTokenRefresher.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokenRefresher.java
@@ -48,8 +48,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import static java.util.stream.Collectors.joining;
-
 class AccessTokenRefresher implements AccessTokens, Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(AccessTokenRefresher.class);
 
@@ -150,7 +148,11 @@ class AccessTokenRefresher implements AccessTokens, Runnable {
     }
 
     private static String joinScopes(final Collection<Object> scopes) {
-        return scopes.stream().map(Object::toString).collect(joining(" "));
+        StringBuilder joined = new StringBuilder(scopes.size() * 15);
+        for (Object scope : scopes) {
+            joined.append(scope).append(" ");
+        }
+        return joined.toString().trim();
     }
 
     private AccessToken createToken(final AccessTokenConfiguration tokenConfig) {

--- a/src/main/java/org/zalando/stups/tokens/AccessTokensBuilder.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokensBuilder.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,7 +16,6 @@
 package org.zalando.stups.tokens;
 
 import java.net.URI;
-
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -76,13 +75,10 @@ public class AccessTokensBuilder {
         return this;
     }
 
-    public AccessTokenConfiguration manageToken(final Object tokenId) {
+    public AccessTokenConfigurationBuilder manageToken(final Object tokenId) {
         checkLock();
         checkNotNull("tokenId", tokenId);
-
-        final AccessTokenConfiguration config = new AccessTokenConfiguration(tokenId, this);
-        accessTokenConfigurations.add(config);
-        return config;
+        return new AccessTokenConfigurationBuilder(tokenId, this);
     }
 
     URI getAccessTokenUri() {
@@ -103,6 +99,10 @@ public class AccessTokensBuilder {
 
     int getWarnPercentLeft() {
         return warnPercentLeft;
+    }
+
+    void addAccessTokenConfigurations(final AccessTokenConfiguration configuration) {
+        accessTokenConfigurations.add(configuration);
     }
 
     Set<AccessTokenConfiguration> getAccessTokenConfigurations() {

--- a/src/main/java/org/zalando/stups/tokens/AccessTokensBuilder.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokensBuilder.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/zalando/stups/tokens/FileSupplier.java
+++ b/src/main/java/org/zalando/stups/tokens/FileSupplier.java
@@ -15,16 +15,16 @@
  */
 package org.zalando.stups.tokens;
 
-import java.io.File;
-
 import org.apache.http.util.Args;
+
+import java.io.File;
 
 /**
  * Replacement to make it compatible with Java7.
  *
- * @author  jbellmann
+ * @author jbellmann
  */
-class FileSupplier {
+class FileSupplier implements Supplier<File> {
 
     private File file;
     private final String filename;
@@ -38,6 +38,7 @@ class FileSupplier {
         this.filename = Args.notBlank(filename, "filename");
     }
 
+    @Override
     public synchronized File get() {
         if (file != null) {
             return file;

--- a/src/main/java/org/zalando/stups/tokens/ScopeConfigurationBuilder.java
+++ b/src/main/java/org/zalando/stups/tokens/ScopeConfigurationBuilder.java
@@ -16,9 +16,9 @@
 package org.zalando.stups.tokens;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Set;
-import java.util.function.Supplier;
+
+import static java.util.Collections.unmodifiableSet;
 
 abstract class ScopeConfigurationBuilder {
 
@@ -34,7 +34,7 @@ abstract class ScopeConfigurationBuilder {
 
     protected abstract AccessTokenConfiguration.ScopeConfiguration build();
 
-    static class Static extends ScopeConfigurationBuilder {
+    public static class Static extends ScopeConfigurationBuilder {
         private final Set<Object> scopes;
 
         public Static(final AccessTokenConfigurationBuilder builder,
@@ -55,11 +55,16 @@ abstract class ScopeConfigurationBuilder {
 
         @Override
         protected AccessTokenConfiguration.ScopeConfiguration build() {
-            return () -> Collections.unmodifiableSet(scopes);
+            return new AccessTokenConfiguration.ScopeConfiguration() {
+                @Override
+                public Set<Object> getScopes() {
+                    return unmodifiableSet(scopes);
+                }
+            };
         }
     }
 
-    static class Dynamic extends ScopeConfigurationBuilder {
+    public static class Dynamic extends ScopeConfigurationBuilder {
 
         private final Supplier<Set<Object>> scopeSupplier;
 
@@ -71,7 +76,12 @@ abstract class ScopeConfigurationBuilder {
 
         @Override
         protected AccessTokenConfiguration.ScopeConfiguration build() {
-            return () -> Collections.unmodifiableSet(scopeSupplier.get());
+            return new AccessTokenConfiguration.ScopeConfiguration() {
+                @Override
+                public Set<Object> getScopes() {
+                    return unmodifiableSet(scopeSupplier.get());
+                }
+            };
         }
     }
 }

--- a/src/main/java/org/zalando/stups/tokens/ScopeConfigurationBuilder.java
+++ b/src/main/java/org/zalando/stups/tokens/ScopeConfigurationBuilder.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/org/zalando/stups/tokens/ScopeConfigurationBuilder.java
+++ b/src/main/java/org/zalando/stups/tokens/ScopeConfigurationBuilder.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zalando.stups.tokens;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.function.Supplier;
+
+abstract class ScopeConfigurationBuilder {
+
+    protected final AccessTokenConfigurationBuilder builder;
+
+    public ScopeConfigurationBuilder(final AccessTokenConfigurationBuilder builder) {
+        this.builder = builder;
+    }
+
+    public AccessTokensBuilder done() {
+        return builder.build(build());
+    }
+
+    protected abstract AccessTokenConfiguration.ScopeConfiguration build();
+
+    static class Static extends ScopeConfigurationBuilder {
+        private final Set<String> scopes;
+
+        public Static(final AccessTokenConfigurationBuilder builder,
+                final Set<String> scopes) {
+            super(builder);
+            this.scopes = scopes;
+        }
+
+        public Static addScope(final String scope) {
+            scopes.add(scope);
+            return this;
+        }
+
+        public Static addScopes(final Collection<String> newScopes) {
+            scopes.addAll(newScopes);
+            return this;
+        }
+
+        @Override
+        protected AccessTokenConfiguration.ScopeConfiguration build() {
+            return () -> Collections.unmodifiableSet(scopes);
+        }
+    }
+
+    static class Dynamic extends ScopeConfigurationBuilder {
+
+        private final Supplier<Set<String>> scopeSupplier;
+
+        public Dynamic(final AccessTokenConfigurationBuilder builder,
+                final Supplier<Set<String>> scopeSupplier) {
+            super(builder);
+            this.scopeSupplier = scopeSupplier;
+        }
+
+        @Override
+        protected AccessTokenConfiguration.ScopeConfiguration build() {
+            return () -> Collections.unmodifiableSet(scopeSupplier.get());
+        }
+    }
+}

--- a/src/main/java/org/zalando/stups/tokens/ScopeConfigurationBuilder.java
+++ b/src/main/java/org/zalando/stups/tokens/ScopeConfigurationBuilder.java
@@ -35,20 +35,20 @@ abstract class ScopeConfigurationBuilder {
     protected abstract AccessTokenConfiguration.ScopeConfiguration build();
 
     static class Static extends ScopeConfigurationBuilder {
-        private final Set<String> scopes;
+        private final Set<Object> scopes;
 
         public Static(final AccessTokenConfigurationBuilder builder,
-                final Set<String> scopes) {
+                final Set<Object> scopes) {
             super(builder);
             this.scopes = scopes;
         }
 
-        public Static addScope(final String scope) {
+        public Static addScope(final Object scope) {
             scopes.add(scope);
             return this;
         }
 
-        public Static addScopes(final Collection<String> newScopes) {
+        public Static addScopes(final Collection<Object> newScopes) {
             scopes.addAll(newScopes);
             return this;
         }
@@ -61,10 +61,10 @@ abstract class ScopeConfigurationBuilder {
 
     static class Dynamic extends ScopeConfigurationBuilder {
 
-        private final Supplier<Set<String>> scopeSupplier;
+        private final Supplier<Set<Object>> scopeSupplier;
 
         public Dynamic(final AccessTokenConfigurationBuilder builder,
-                final Supplier<Set<String>> scopeSupplier) {
+                final Supplier<Set<Object>> scopeSupplier) {
             super(builder);
             this.scopeSupplier = scopeSupplier;
         }

--- a/src/main/java/org/zalando/stups/tokens/Supplier.java
+++ b/src/main/java/org/zalando/stups/tokens/Supplier.java
@@ -15,28 +15,16 @@
  */
 package org.zalando.stups.tokens;
 
-import java.util.Set;
+/**
+ * Backport of Java8 java.util.Supplier
+ */
+public interface Supplier<T> {
 
-public class AccessTokenConfiguration {
+    /**
+     * Gets a result.
+     *
+     * @return a result
+     */
+    T get();
 
-    interface ScopeConfiguration {
-        Set<Object> getScopes();
-    }
-
-    private final Object tokenId;
-
-    private final ScopeConfiguration scopeConfiguration;
-
-    AccessTokenConfiguration(final Object tokenId, final ScopeConfiguration scopeConfiguration) {
-        this.tokenId = tokenId;
-        this.scopeConfiguration = scopeConfiguration;
-    }
-
-    Object getTokenId() {
-        return tokenId;
-    }
-
-    Set<Object> getScopes() {
-        return scopeConfiguration.getScopes();
-    }
 }

--- a/src/test/java/org/zalando/stups/example/TokensApiTest.java
+++ b/src/test/java/org/zalando/stups/example/TokensApiTest.java
@@ -13,13 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zalando.stups.tokens;
+package org.zalando.stups.example;
 
 import org.junit.Test;
+import org.zalando.stups.tokens.AccessTokens;
+import org.zalando.stups.tokens.Supplier;
+import org.zalando.stups.tokens.Tokens;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Testing whether the API actually provides the functionality we expose in the README
@@ -43,10 +47,20 @@ public class TokensApiTest {
     public void testDynamicUsage() throws URISyntaxException {
         AccessTokens tokens = Tokens.createAccessTokensWithUri(new URI("https://example.com/access_tokens"))
                 .manageToken("a")
-                .addScope(() -> "x")
+                .addScope(new Supplier<Object>() {
+                    @Override
+                    public Object get() {
+                        return "x";
+                    }
+                })
                 .done()
                 .manageToken("b")
-                .addScopes(HashSet::new)
+                .addScopes(new Supplier<Set<Object>>() {
+                    @Override
+                    public Set<Object> get() {
+                        return new HashSet<>();
+                    }
+                })
                 .done()
                 .start();
     }

--- a/src/test/java/org/zalando/stups/tokens/AccessTokensBuilderTest.java
+++ b/src/test/java/org/zalando/stups/tokens/AccessTokensBuilderTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zalando.stups.tokens;
+
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+public class AccessTokensBuilderTest {
+
+    @Test
+    public void testMultipleTokens() {
+        final AccessTokensBuilder builder = Tokens.createAccessTokensWithUri(URI.create("http://example.com"))
+                .manageToken("token1")
+                .addScope("scope")
+                .done()
+                .manageToken("token2")
+                .addScope("scope")
+                .done();
+
+        final ArrayList<AccessTokenConfiguration> configurations = new ArrayList<>(builder.getAccessTokenConfigurations());
+        assertThat(configurations, hasSize(2));
+
+        final AccessTokenConfiguration configuration1 = configurations.get(0);
+        final AccessTokenConfiguration configuration2 = configurations.get(1);
+
+        assertThat(configuration1.getTokenId(), is((Object) "token1"));
+        assertThat(configuration1.getScopes(), hasSize(1));
+        assertThat(configuration2.getTokenId(), is((Object) "token2"));
+        assertThat(configuration2.getScopes(), hasSize(1));
+    }
+
+    @Test
+    public void testDynamicScope() {
+        final AccessTokensBuilder builder = Tokens.createAccessTokensWithUri(URI.create("http://example.com"))
+                .manageToken("token")
+                .addScope(new Supplier<Object>() {
+                    @Override
+                    public Object get() {
+                        return "scope";
+                    }
+                })
+                .done();
+
+        final AccessTokenConfiguration configuration = builder.getAccessTokenConfigurations().iterator().next();
+        assertThat(configuration.getTokenId(), is((Object) "token"));
+        assertThat(configuration.getScopes(), hasSize(1));
+        assertThat(configuration.getScopes().iterator().next(), is((Object) "scope"));
+    }
+
+    @Test
+    public void testDynamicScopes() {
+        final AccessTokensBuilder builder = Tokens.createAccessTokensWithUri(URI.create("http://example.com"))
+                .manageToken("token")
+                .addScopes(new Supplier<Set<Object>>() {
+                    @Override
+                    public Set<Object> get() {
+                        return new HashSet<Object>(asList("scope1", "scope2"));
+                    }
+                })
+                .done();
+
+        final AccessTokenConfiguration configuration = builder.getAccessTokenConfigurations().iterator().next();
+        assertThat(configuration.getTokenId(), is((Object) "token"));
+        assertThat(configuration.getScopes(), hasSize(2));
+
+        final Iterator<Object> scopes = configuration.getScopes().iterator();
+        assertThat(scopes.next(), is((Object) "scope1"));
+        assertThat(scopes.next(), is((Object) "scope2"));
+    }
+}

--- a/src/test/java/org/zalando/stups/tokens/TokensApiTest.java
+++ b/src/test/java/org/zalando/stups/tokens/TokensApiTest.java
@@ -1,0 +1,39 @@
+package org.zalando.stups.tokens;
+
+import org.junit.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashSet;
+
+/**
+ * Testing whether the API actually provides the functionality we expose in the README
+ */
+public class TokensApiTest {
+
+    @Test
+    public void testExampleUsage() throws URISyntaxException {
+        AccessTokens tokens = Tokens.createAccessTokensWithUri(new URI("https://example.com/access_tokens"))
+                .manageToken("exampleRW")
+                .addScope("read")
+                .addScope("write")
+                .done()
+                .manageToken("exampleRO")
+                .addScope("read")
+                .done()
+                .start();
+    }
+
+    @Test
+    public void testDynamicUsage() throws URISyntaxException {
+        AccessTokens tokens = Tokens.createAccessTokensWithUri(new URI("https://example.com/access_tokens"))
+                .manageToken("a")
+                .addScope(() -> "x")
+                .done()
+                .manageToken("b")
+                .addScopes(HashSet::new)
+                .done()
+                .start();
+    }
+
+}

--- a/src/test/java/org/zalando/stups/tokens/TokensApiTest.java
+++ b/src/test/java/org/zalando/stups/tokens/TokensApiTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.zalando.stups.tokens;
 
 import org.junit.Test;


### PR DESCRIPTION
Adding a new configuration option to allow scopes to be defined
dynamically per token. You cannot mix both approaches on a token.

Additionally the scope interface has been changed to expected a String
instead of an Object.