### PR TITLE
#56 Should add type safe `addScope` and `addScopesTypeSafe methods`

### DIFF
--- a/src/main/java/org/zalando/stups/tokens/AccessTokenConfiguration.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokenConfiguration.java
@@ -16,6 +16,7 @@
 package org.zalando.stups.tokens;
 
 import static org.zalando.stups.tokens.util.Objects.noNullEntries;
+import static org.zalando.stups.tokens.util.Objects.noBlankEntries;
 import static org.zalando.stups.tokens.util.Objects.notBlank;
 import static org.zalando.stups.tokens.util.Objects.notNull;
 
@@ -75,10 +76,29 @@ public class AccessTokenConfiguration {
 	 *               will be thrown in case of <i>scope</i> being <i>null</i>.
 	 * @return The same {@link AccessTokenConfiguration} instance this method has been called upon
 	 * with the supplied <i>scope</i> added to the set of existing scopes.
-     */
+	 *
+	 * @deprecated Use {@link AccessTokenConfiguration#addScope(String)} instead and invoke
+	 * {@link Object#toString()} before if necessary.
+   */
+	@Deprecated
 	public AccessTokenConfiguration addScope(final Object scope) {
 		checkLock();
 		scopes.add(notNull("scope", scope));
+		return this;
+	}
+
+	/**
+	 * Add a single scope to this access token.
+	 *
+	 * @param scope  The scope to add for this access token. An {@link IllegalArgumentException}
+	 *               will be thrown in case of <i>scope</i> being <i>null</i> or <i>empty</i>.
+	 * @return The same {@link AccessTokenConfiguration} instance this method has been called upon
+	 * with the supplied <i>scope</i> added to the set of existing scopes.
+	 *
+   */
+	public AccessTokenConfiguration addScope(final String scope) {
+		checkLock();
+		scopes.add(notBlank("scope", scope));
 		return this;
 	}
 
@@ -95,10 +115,34 @@ public class AccessTokenConfiguration {
 	 *                will be removed.
 	 * @return The same {@link AccessTokenConfiguration} instance this method has been called upon
 	 * with the supplied <i>scopes</i> added to the set of existing scopes.
-     */
+	 *
+	 * @deprecated Use {@link AccessTokenConfiguration#addScopesTypeSafe(Collection)} instead and
+	 * invoke {@link Object#toString()} on each element before if necessary
+   */
+	@Deprecated
 	public AccessTokenConfiguration addScopes(final Collection<?> scopes) {
 		checkLock();
-		this.scopes.addAll(noNullEntries("scopes", notNull("scopes", scopes)));
+		this.scopes.addAll(noNullEntries("scopes", scopes));
+		return this;
+	}
+
+	/**
+	 * Add multiple scopes to this access token. Refer to
+	 * {@link AccessTokenConfiguration#addScope(Object)} for more detailed description of a scope.
+	 *
+	 * @param scopes  A {@link Collection} of scopes that should be added to this access token. An
+	 *                {@link IllegalArgumentException} will be throws if either <i>scopes</i> being
+	 *                <i>null</i> or {@link Collection#contains(Object)} is <i>true</i> for the
+	 *                <i>null</i> arguments.
+	 *                Please note that scopes are stored as {@link Set} internally, i.e. duplicates
+	 *                with respect to {@link Object#hashCode()} and {@link Object#equals(Object)}
+	 *                will be removed.
+	 * @return The same {@link AccessTokenConfiguration} instance this method has been called upon
+	 * with the supplied <i>scopes</i> added to the set of existing scopes.
+	 */
+	public AccessTokenConfiguration addScopesTypeSafe(final Collection<String> scopes) {
+		checkLock();
+		this.scopes.addAll(noBlankEntries("scopes", scopes));
 		return this;
 	}
 
@@ -109,7 +153,7 @@ public class AccessTokenConfiguration {
 	 * @param grantType  The <i>grant type</i> to be used when requesting an access token.
 	 * @return The same {@link AccessTokenConfiguration} instance this method has been called upon
 	 * with the supplied <i>grant type</i> set.
-     */
+   */
 	public AccessTokenConfiguration withGrantType(final String grantType) {
 		checkLock();
 		this.grantType = Objects.notBlank("grantType", notNull("grantType", grantType));

--- a/src/main/java/org/zalando/stups/tokens/util/Objects.java
+++ b/src/main/java/org/zalando/stups/tokens/util/Objects.java
@@ -54,4 +54,25 @@ public class Objects {
 		return collection;
 	}
 
+	public static <T extends CharSequence> Collection<T> noBlankEntries(String name, Collection<T> collection) {
+		name = notBlank("name", name);
+		collection = notNull(name, collection);
+		try {
+			if (collection.contains(null)) {
+				throw new IllegalArgumentException(name + " should not contain 'null'");
+			}
+			try {
+				for (T element : collection) {
+					Args.notBlank(element, name);
+				}
+			} catch (IllegalArgumentException ignore) {
+				throw new IllegalArgumentException(name + " should not contain blank elements");
+			}
+		} catch (NullPointerException e) {
+			return collection;
+		}
+
+		return collection;
+	}
+
 }

--- a/src/test/java/org/zalando/stups/tokens/AccessTokenConfigurationTest.java
+++ b/src/test/java/org/zalando/stups/tokens/AccessTokenConfigurationTest.java
@@ -69,6 +69,38 @@ public class AccessTokenConfigurationTest {
 		Assertions.assertThat(configuration.getScopes()).containsExactly(scope);
 	}
 
+	@Test
+	public void addStringScope() {
+		String scope = "scope";
+		AccessTokenConfiguration configuration = new AccessTokenConfiguration(new Object(), builder);
+		configuration.addScope(scope);
+		Assertions.assertThat(configuration.getScopes()).containsExactly(scope);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void addingNullScope() {
+		String scope = null;
+		AccessTokenConfiguration configuration = new AccessTokenConfiguration(new Object(), builder);
+		configuration.addScope(scope);
+		Assertions.fail("This code should not be reached");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void addingEmptyScope() {
+		String scope = "";
+		AccessTokenConfiguration configuration = new AccessTokenConfiguration(new Object(), builder);
+		configuration.addScope(scope);
+		Assertions.fail("This code should not be reached");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void addingBlankScope() {
+		String scope = " ";
+		AccessTokenConfiguration configuration = new AccessTokenConfiguration(new Object(), builder);
+		configuration.addScope(scope);
+		Assertions.fail("This code should not be reached");
+	}
+
 	@Test(expected = IllegalArgumentException.class)
 	public void addingScopes() {
 		Object scope = new Object();
@@ -77,6 +109,28 @@ public class AccessTokenConfigurationTest {
 		scopes.add(null);
 		scopes.add(scope);
 		configuration.addScopes(scopes);
+		Assertions.fail("This code should not be reached");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void addingNullScopesTypeSafe() {
+		String scope = "scope";
+		AccessTokenConfiguration configuration = new AccessTokenConfiguration(new Object(), builder);
+		List<String> scopes = new ArrayList<>();
+		scopes.add(null);
+		scopes.add(scope);
+		configuration.addScopesTypeSafe(scopes);
+		Assertions.fail("This code should not be reached");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void addingBlankScopesTypeSafe() {
+		String scope = "scope";
+		AccessTokenConfiguration configuration = new AccessTokenConfiguration(new Object(), builder);
+		List<String> scopes = new ArrayList<>();
+		scopes.add(" ");
+		scopes.add(scope);
+		configuration.addScopesTypeSafe(scopes);
 		Assertions.fail("This code should not be reached");
 	}
 


### PR DESCRIPTION
When using the strong typed version the library will not allow to add null, empty or blank scopes.

Due to the type erasure problem with Java the `addScopes` method cannot be nicely overloaded. Its type safe version is (now) called `addScopesTypeSafe`. Once the original method has been removed this method could in turn be flagged as Deprecated and the new type safe `addScopes` method could be added.

@jhorstmann / @mastersimon / @harti2006 / @jbellmann  what's your opinion on that PR? Would fix #56 

/cc @sarnowski as he's been mentioned on the issue as well