### PR TITLE
Make the refresher thread a daemon thread

### DIFF
--- a/src/main/java/org/zalando/stups/tokens/AccessTokensBuilder.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokensBuilder.java
@@ -187,7 +187,7 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
      * implementation instead of creating a new one.
      *
      * If none is supplied a new one will be created using
-     * {@link Executors#newSingleThreadScheduledExecutor()} upon start.
+     * {@link Executors#newSingleThreadScheduledExecutor(new TokenRefresherThreadFactory())} upon start.
      *
      * @param executorService
      *            Your version of the {@link ScheduledExecutorService} to be
@@ -195,6 +195,9 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
      * @return The same {@link AccessTokensBuilder} instance this method has
      *         been called upon with the supplied
      *         {@link ScheduledExecutorService} set.
+     *
+     * @see TokenRefresherThreadFactory
+     * @see Executors#newSingleThreadExecutor(java.util.concurrent.ThreadFactory)
      */
     public AccessTokensBuilder existingExecutorService(final ScheduledExecutorService executorService) {
         checkLock();

--- a/src/main/java/org/zalando/stups/tokens/AccessTokensBuilder.java
+++ b/src/main/java/org/zalando/stups/tokens/AccessTokensBuilder.java
@@ -28,14 +28,17 @@ import java.util.concurrent.TimeUnit;
 import org.zalando.stups.tokens.mcb.MCBConfig;
 
 /**
- * Use the <i>AccessTokensBuilder</i> obtained via {@link Tokens#createAccessTokensWithUri(URI)} to
- * build your configuration for obtaining an {@link AccessToken} for different scopes / services
- * via the {@link AccessTokens#getAccessToken(Object)} or {@link AccessTokens#get(Object)} methods
- * on the instance returned after invoking {@link AccessTokensBuilder#start()}.
+ * Use the <i>AccessTokensBuilder</i> obtained via
+ * {@link Tokens#createAccessTokensWithUri(URI)} to build your configuration for
+ * obtaining an {@link AccessToken} for different scopes / services via the
+ * {@link AccessTokens#getAccessToken(Object)} or
+ * {@link AccessTokens#get(Object)} methods on the instance returned after
+ * invoking {@link AccessTokensBuilder#start()}.
  *
- * This class offers a Fluent Interface type of Builder. You can invoke any of the methods on the
- * initially retrieved instance until you call {@link AccessTokensBuilder#start()}. Invoking any at
- * any later point of time will throw an {@link IllegalStateException}.
+ * This class offers a Fluent Interface type of Builder. You can invoke any of
+ * the methods on the initially retrieved instance until you call
+ * {@link AccessTokensBuilder#start()}. Invoking any at any later point of time
+ * will throw an {@link IllegalStateException}.
  *
  */
 public class AccessTokensBuilder implements TokenRefresherConfiguration {
@@ -78,19 +81,22 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     }
 
     /**
-     * Use the supplied implementation of {@link ClientCredentialsProvider} to create the
-     * {@link ClientCredentials} which will be used to authenticate the client when requesting a new
-     * access token.
+     * Use the supplied implementation of {@link ClientCredentialsProvider} to
+     * create the {@link ClientCredentials} which will be used to authenticate
+     * the client when requesting a new access token.
      *
-     * See https://tools.ietf.org/html/rfc6749#section-1.3.4 for further information on the meaning
-     * of client credentials in the context of OAuth2.0
+     * See https://tools.ietf.org/html/rfc6749#section-1.3.4 for further
+     * information on the meaning of client credentials in the context of
+     * OAuth2.0
      *
-     * @param clientCredentialsProvider  Your implementation of the {@link ClientCredentialsProvider}
-     *                                   interface to use. See
-     *                                   {@link JsonFileBackedClientCredentialsProvider} for a
-     *                                   potential implementation
-     * @return The same {@link AccessTokensBuilder} instance this method has been called upon with
-     * the supplied {@link ClientCredentialsProvider} set.
+     * @param clientCredentialsProvider
+     *            Your implementation of the {@link ClientCredentialsProvider}
+     *            interface to use. See
+     *            {@link JsonFileBackedClientCredentialsProvider} for a
+     *            potential implementation
+     * @return The same {@link AccessTokensBuilder} instance this method has
+     *         been called upon with the supplied
+     *         {@link ClientCredentialsProvider} set.
      */
     public AccessTokensBuilder usingClientCredentialsProvider(
             final ClientCredentialsProvider clientCredentialsProvider) {
@@ -100,19 +106,21 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     }
 
     /**
-     * Use the supplied implementation of {@link UserCredentialsProvider} to create the
-     * {@link UserCredentials} which will be used to authenticate the user when requesting a new
-     * access token.
+     * Use the supplied implementation of {@link UserCredentialsProvider} to
+     * create the {@link UserCredentials} which will be used to authenticate the
+     * user when requesting a new access token.
      *
-     * See https://tools.ietf.org/html/rfc6749#section-1.3.3 for further information on the meaning
-     * of user credentials and how they can be used.
+     * See https://tools.ietf.org/html/rfc6749#section-1.3.3 for further
+     * information on the meaning of user credentials and how they can be used.
      *
-     * @param userCredentialsProvider  Your implementation of the {@link UserCredentialsProvider}
-     *                                 interface to use. See
-     *                                 {@link JsonFileBackedUserCredentialsProvider} for a
-     *                                 potential implementation
-     * @return The same {@link AccessTokensBuilder} instance this method has been called upon with
-     * the supplied {@link UserCredentialsProvider} set.
+     * @param userCredentialsProvider
+     *            Your implementation of the {@link UserCredentialsProvider}
+     *            interface to use. See
+     *            {@link JsonFileBackedUserCredentialsProvider} for a potential
+     *            implementation
+     * @return The same {@link AccessTokensBuilder} instance this method has
+     *         been called upon with the supplied
+     *         {@link UserCredentialsProvider} set.
      */
     public AccessTokensBuilder usingUserCredentialsProvider(final UserCredentialsProvider userCredentialsProvider) {
         checkLock();
@@ -121,13 +129,17 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     }
 
     /**
-     * Use the supplied implementation of {@link HttpProviderFactory} to create the
-     * {@link HttpProvider} which will be used for requesting new access tokens.
+     * Use the supplied implementation of {@link HttpProviderFactory} to create
+     * the {@link HttpProvider} which will be used for requesting new access
+     * tokens.
      *
-     * @param factory  Your implementation of the {@link HttpProviderFactory} to use. See
-     *                 {@link ClosableHttpProviderFactory} for a potential implementation.
-     * @return The same {@link AccessTokensBuilder} instance this method has been called upon with
-     * the supplied {@link HttpProviderFactory} set.
+     * @param factory
+     *            Your implementation of the {@link HttpProviderFactory} to use.
+     *            See {@link ClosableHttpProviderFactory} for a potential
+     *            implementation.
+     * @return The same {@link AccessTokensBuilder} instance this method has
+     *         been called upon with the supplied {@link HttpProviderFactory}
+     *         set.
      */
     public AccessTokensBuilder usingHttpProviderFactory(final HttpProviderFactory factory) {
         checkLock();
@@ -136,14 +148,17 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     }
 
     /**
-     * Use the supplied implementation of {@link TokenVerifierProvider} to create the
-     * {@link TokenVerifier} to use for verifying access and refresh tokens
+     * Use the supplied implementation of {@link TokenVerifierProvider} to
+     * create the {@link TokenVerifier} to use for verifying access and refresh
+     * tokens
      *
-     * @param tokenVerifierProvider  Your implementation of the {@link TokenVerifierProvider} to
-     *                               user. See {@link CloseableTokenVerifierProvider} for a
-     *                               potential implementation.
-     * @return The same {@link AccessTokensBuilder} instance this method has been called upon with
-     * the supplied {@link TokenVerifierProvider} set.
+     * @param tokenVerifierProvider
+     *            Your implementation of the {@link TokenVerifierProvider} to
+     *            user. See {@link CloseableTokenVerifierProvider} for a
+     *            potential implementation.
+     * @return The same {@link AccessTokensBuilder} instance this method has
+     *         been called upon with the supplied {@link TokenVerifierProvider}
+     *         set.
      */
     public AccessTokensBuilder usingTokenVerifierProvider(TokenVerifierProvider tokenVerifierProvider) {
         checkLock();
@@ -152,12 +167,13 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     }
 
     /**
-     * Change the socket timeout in milliseconds to be used for HTTP connections. Default value is
-     * 2000.
+     * Change the socket timeout in milliseconds to be used for HTTP
+     * connections. Default value is 2000.
      *
-     * @param socketTimeout  Your desired socket timeout in milliseconds
-     * @return The same {@link AccessTokensBuilder} instance this method has been called upon with
-     * the supplied <i>socket timeout</i> set.
+     * @param socketTimeout
+     *            Your desired socket timeout in milliseconds
+     * @return The same {@link AccessTokensBuilder} instance this method has
+     *         been called upon with the supplied <i>socket timeout</i> set.
      */
     public AccessTokensBuilder socketTimeout(final int socketTimeout) {
         checkLock();
@@ -166,29 +182,34 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     }
 
     /**
-     * Use the supplied existing {@link ScheduledExecutorService} for all scheduled operations done
-     * by the created {@link AccessTokens} implementation instead of creating a new one.
+     * Use the supplied existing {@link ScheduledExecutorService} for all
+     * scheduled operations done by the created {@link AccessTokens}
+     * implementation instead of creating a new one.
      *
      * If none is supplied a new one will be created using
      * {@link Executors#newSingleThreadScheduledExecutor()} upon start.
      *
-     * @param executorService  Your version of the {@link ScheduledExecutorService} to be used.
-     * @return The same {@link AccessTokensBuilder} instance this method has been called upon with
-     * the supplied {@link ScheduledExecutorService} set.
+     * @param executorService
+     *            Your version of the {@link ScheduledExecutorService} to be
+     *            used.
+     * @return The same {@link AccessTokensBuilder} instance this method has
+     *         been called upon with the supplied
+     *         {@link ScheduledExecutorService} set.
      */
     public AccessTokensBuilder existingExecutorService(final ScheduledExecutorService executorService) {
         checkLock();
-        this.executorService = notNull("executorService",executorService);
+        this.executorService = notNull("executorService", executorService);
         return this;
     }
 
     /**
-     * Change the connect timeout in milliseconds to be used for HTTP connections. Default value is
-     * 1000.
+     * Change the connect timeout in milliseconds to be used for HTTP
+     * connections. Default value is 1000.
      *
-     * @param connectTimeout  Your desired connect timeout in milliseconds
-     * @return The same {@link AccessTokensBuilder} instance this method has been called upon with
-     * the supplied <i>connect timeout</i> set.
+     * @param connectTimeout
+     *            Your desired connect timeout in milliseconds
+     * @return The same {@link AccessTokensBuilder} instance this method has
+     *         been called upon with the supplied <i>connect timeout</i> set.
      */
     public AccessTokensBuilder connectTimeout(final int connectTimeout) {
         checkLock();
@@ -197,12 +218,15 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     }
 
     /**
-     * Change the connection request timeout in milliseconds to be used for requesting new HTTP
-     * connections from the connection manager. Default value is 500.
+     * Change the connection request timeout in milliseconds to be used for
+     * requesting new HTTP connections from the connection manager. Default
+     * value is 500.
      *
-     * @param connectionRequestTimeout  Your desired connection request timeout in milliseconds
-     * @return The same {@link AccessTokensBuilder} instance this method has been called upon with
-     * the supplied <i>connection request timeout</i> set.
+     * @param connectionRequestTimeout
+     *            Your desired connection request timeout in milliseconds
+     * @return The same {@link AccessTokensBuilder} instance this method has
+     *         been called upon with the supplied <i>connection request
+     *         timeout</i> set.
      */
     public AccessTokensBuilder connectionRequestTimeout(final int connectionRequestTimeout) {
         checkLock();
@@ -211,13 +235,16 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     }
 
     /**
-     * Change whether the stale connection check should be enabled or disabled when requesting a
-     * HTTP connection from the connection manager. Default behaviour is enabled.
+     * Change whether the stale connection check should be enabled or disabled
+     * when requesting a HTTP connection from the connection manager. Default
+     * behaviour is enabled.
      *
-     * @param staleConnectionCheckEnabled  True in case the stale connection check should be enabled
-     *                                     false otherwise
-     * @return The same {@link AccessTokensBuilder} instance this method has been called upon with
-     * the supplied <i>stale connection check value</i> set.
+     * @param staleConnectionCheckEnabled
+     *            True in case the stale connection check should be enabled
+     *            false otherwise
+     * @return The same {@link AccessTokensBuilder} instance this method has
+     *         been called upon with the supplied <i>stale connection check
+     *         value</i> set.
      */
     public AccessTokensBuilder staleConnectionCheckEnabled(final boolean staleConnectionCheckEnabled) {
         checkLock();
@@ -226,13 +253,16 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     }
 
     /**
-     * Set the threshold of the validity time left before the service tries to refresh an access
-     * token with the authorization server. Default value is 40.
+     * Set the threshold of the validity time left before the service tries to
+     * refresh an access token with the authorization server. Default value is
+     * 40.
      *
-     * @param refreshPercentLeft  The percentage of validity time left that triggers refreshing an
-     *                            access token
-     * @return The same {@link AccessTokensBuilder} instance this method has been called upon with
-     * the supplied <i>refresh percentage left</i> set.
+     * @param refreshPercentLeft
+     *            The percentage of validity time left that triggers refreshing
+     *            an access token
+     * @return The same {@link AccessTokensBuilder} instance this method has
+     *         been called upon with the supplied <i>refresh percentage left</i>
+     *         set.
      */
     public AccessTokensBuilder refreshPercentLeft(final int refreshPercentLeft) {
         checkLock();
@@ -241,12 +271,15 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     }
 
     /**
-     * Set the threshold of the validity time left before the service issues a warning. This value
-     * can be used to detect possible access token refreshing problems e.g. Default value is 20.
+     * Set the threshold of the validity time left before the service issues a
+     * warning. This value can be used to detect possible access token
+     * refreshing problems e.g. Default value is 20.
      *
-     * @param warnPercentLeft  The percentage of validity time left that triggers a warning
-     * @return The same {@link AccessTokensBuilder} instance this method has been called upon with
-     * the supplied <i>warn percentage left</i> set.
+     * @param warnPercentLeft
+     *            The percentage of validity time left that triggers a warning
+     * @return The same {@link AccessTokensBuilder} instance this method has
+     *         been called upon with the supplied <i>warn percentage left</i>
+     *         set.
      */
     public AccessTokensBuilder warnPercentLeft(final int warnPercentLeft) {
         checkLock();
@@ -255,25 +288,29 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     }
 
     /**
-     * Configure a new access token configuration that should be managed by the returned
-     * {@link AccessTokens} implementation. You can manage multiple different tokens by invoking
-     * this method multiple times with different values for <i>tokenId</i>.
+     * Configure a new access token configuration that should be managed by the
+     * returned {@link AccessTokens} implementation. You can manage multiple
+     * different tokens by invoking this method multiple times with different
+     * values for <i>tokenId</i>.
      *
-     * You can e.g. manage a read only token as well as a write token. It is considered best
-     * practice to use as limited scopes as reasonable to mitigate the security implications that
-     * arise by leaked access tokens.
+     * You can e.g. manage a read only token as well as a write token. It is
+     * considered best practice to use as limited scopes as reasonable to
+     * mitigate the security implications that arise by leaked access tokens.
      *
-     * @param tokenId  A unique id for this specific access token configuration. The supplied object
-     *                 must implement {@link Object#equals(Object)} in a way that it identifies the
-     *                 same value correctly. A straight forward version would be using a
-     *                 {@link String} value.
-     * @return An instance of {@link AccessTokenConfiguration} which offers a fluent interface type
-     * of configuration for a single <i>tokenId</i>. Use the returned object to configure e.g the
-     * scopes for that specific token.
+     * @param tokenId
+     *            A unique id for this specific access token configuration. The
+     *            supplied object must implement {@link Object#equals(Object)}
+     *            in a way that it identifies the same value correctly. A
+     *            straight forward version would be using a {@link String}
+     *            value.
+     * @return An instance of {@link AccessTokenConfiguration} which offers a
+     *         fluent interface type of configuration for a single
+     *         <i>tokenId</i>. Use the returned object to configure e.g the
+     *         scopes for that specific token.
      */
     public AccessTokenConfiguration manageToken(final Object tokenId) {
         checkLock();
-        notNull("tokenId",tokenId);
+        notNull("tokenId", tokenId);
 
         final AccessTokenConfiguration config = new AccessTokenConfiguration(tokenId, this);
         accessTokenConfigurations.add(config);
@@ -281,15 +318,16 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     }
 
     /**
-     * Configure the amount of time between two runs of checking which existing access tokens should
-     * be refreshed. This method must be used together with
-     * {@link AccessTokensBuilder#schedulingTimeUnit(TimeUnit)} to define the scheduling. The
-     * meaning of the value supplied here depends on the setting for the {@link TimeUnit}. Default
-     * value is set to 5.
+     * Configure the amount of time between two runs of checking which existing
+     * access tokens should be refreshed. This method must be used together with
+     * {@link AccessTokensBuilder#schedulingTimeUnit(TimeUnit)} to define the
+     * scheduling. The meaning of the value supplied here depends on the setting
+     * for the {@link TimeUnit}. Default value is set to 5.
      *
-     * @param schedulingPeriod  The value for the <i>scheduling period</i> to use.
-     * @return The same {@link AccessTokensBuilder} instance this method has been called upon with
-     * the supplied <i>scheduling period</i> set.
+     * @param schedulingPeriod
+     *            The value for the <i>scheduling period</i> to use.
+     * @return The same {@link AccessTokensBuilder} instance this method has
+     *         been called upon with the supplied <i>scheduling period</i> set.
      */
     public AccessTokensBuilder schedulingPeriod(final int schedulingPeriod) {
         checkLock();
@@ -298,14 +336,15 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     }
 
     /**
-     * Configure the {@link TimeUnit} used together with the configured <i>scheduling period</i> to
-     * use for checking which access tokens should be refreshed. Default value is
-     * {@link TimeUnit#SECONDS}
+     * Configure the {@link TimeUnit} used together with the configured
+     * <i>scheduling period</i> to use for checking which access tokens should
+     * be refreshed. Default value is {@link TimeUnit#SECONDS}
      *
-     * @param timeUnit  The {@link TimeUnit} to use together with the configured <i>scheduling
-     *                  period</i>
-     * @return The same {@link AccessTokensBuilder} instance this method has been called upon with
-     * the supplied {@link TimeUnit} set.
+     * @param timeUnit
+     *            The {@link TimeUnit} to use together with the configured
+     *            <i>scheduling period</i>
+     * @return The same {@link AccessTokensBuilder} instance this method has
+     *         been called upon with the supplied {@link TimeUnit} set.
      */
     public AccessTokensBuilder schedulingTimeUnit(TimeUnit timeUnit) {
         checkLock();
@@ -314,14 +353,18 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     }
 
     /**
-     * Configure the amount of time that should pass between two run of the {@link TokenVerifier}.
-     * The exact meaning of this value depends on the value set by
-     * {@link AccessTokensBuilder#tokenVerifierSchedulingTimeUnit(TimeUnit)}. Default value is 5.
+     * Configure the amount of time that should pass between two run of the
+     * {@link TokenVerifier}. The exact meaning of this value depends on the
+     * value set by
+     * {@link AccessTokensBuilder#tokenVerifierSchedulingTimeUnit(TimeUnit)}.
+     * Default value is 5.
      *
-     * @param tokenVerifierSchedulingPeriod  The value for the <i>token verification scheduling
-     *                                       period</i> to use.
-     * @return The same {@link AccessTokensBuilder} instance this method has been called upon with
-     * the supplied <i>token verification scheduling period</i> set.
+     * @param tokenVerifierSchedulingPeriod
+     *            The value for the <i>token verification scheduling period</i>
+     *            to use.
+     * @return The same {@link AccessTokensBuilder} instance this method has
+     *         been called upon with the supplied <i>token verification
+     *         scheduling period</i> set.
      */
     public AccessTokensBuilder tokenVerifierSchedulingPeriod(int tokenVerifierSchedulingPeriod) {
         checkLock();
@@ -330,14 +373,15 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     }
 
     /**
-     * Configure the {@link TimeUnit} used together with the configured <i>token verification
-     * scheduling period</i> to use for verifying existing access tokens. Default value is
-     * {@link TimeUnit#SECONDS}
+     * Configure the {@link TimeUnit} used together with the configured <i>token
+     * verification scheduling period</i> to use for verifying existing access
+     * tokens. Default value is {@link TimeUnit#SECONDS}
      *
-     * @param timeUnit  The {@link TimeUnit} to use together with the configured <i>token
-     *                  verification scheduling period</i>
-     * @return The same {@link AccessTokensBuilder} instance this method has been called upon with
-     * the supplied {@link TimeUnit} set.
+     * @param timeUnit
+     *            The {@link TimeUnit} to use together with the configured
+     *            <i>token verification scheduling period</i>
+     * @return The same {@link AccessTokensBuilder} instance this method has
+     *         been called upon with the supplied {@link TimeUnit} set.
      */
     public AccessTokensBuilder tokenVerifierSchedulingTimeUnit(TimeUnit timeUnit) {
         checkLock();
@@ -346,12 +390,14 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     }
 
     /**
-     * Configure the <i>token info URI</i> to be used by the {@link TokenVerifier} to verify
-     * existing access tokens.
+     * Configure the <i>token info URI</i> to be used by the
+     * {@link TokenVerifier} to verify existing access tokens.
      *
-     * @param tokenInfoUri  The <i>token info URI</i> to be used by the {@link TokenVerifier}
-     * @return The same {@link AccessTokensBuilder} instance this method has been called upon with
-     * the supplied <i>token info URI</i> set.
+     * @param tokenInfoUri
+     *            The <i>token info URI</i> to be used by the
+     *            {@link TokenVerifier}
+     * @return The same {@link AccessTokensBuilder} instance this method has
+     *         been called upon with the supplied <i>token info URI</i> set.
      */
     public AccessTokensBuilder tokenInfoUri(URI tokenInfoUri) {
         checkLock();
@@ -360,11 +406,14 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     }
 
     /**
-     * Configure the configuration for the circuit breaker to be used for refreshing access tokens.
+     * Configure the configuration for the circuit breaker to be used for
+     * refreshing access tokens.
      *
-     * @param config  The {@link MCBConfig} that should be used for refreshing access tokens.
-     * @return The same {@link AccessTokensBuilder} instance this method has been called upon with
-     * the supplied {@link MCBConfig} set.
+     * @param config
+     *            The {@link MCBConfig} that should be used for refreshing
+     *            access tokens.
+     * @return The same {@link AccessTokensBuilder} instance this method has
+     *         been called upon with the supplied {@link MCBConfig} set.
      */
     public AccessTokensBuilder tokenRefresherMcbConfig(MCBConfig config) {
         checkLock();
@@ -373,11 +422,14 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     }
 
     /**
-     * Configure the configuration for the circuit breaker to be used for verifying access tokens.
+     * Configure the configuration for the circuit breaker to be used for
+     * verifying access tokens.
      *
-     * @param config  The {@link MCBConfig} that should be used for verifying access tokens.
-     * @return The same {@link AccessTokensBuilder} instance this method has been called upon with
-     * the supplied {@link MCBConfig} set.
+     * @param config
+     *            The {@link MCBConfig} that should be used for verifying access
+     *            tokens.
+     * @return The same {@link AccessTokensBuilder} instance this method has
+     *         been called upon with the supplied {@link MCBConfig} set.
      */
     public AccessTokensBuilder tokenVerifierMcbConfig(MCBConfig config) {
         checkLock();
@@ -386,14 +438,15 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     }
 
     /**
-     * Configure the {@link MetricsListener} to be used by the created {@link AccessTokens}
-     * implementation for reporting execution times.
+     * Configure the {@link MetricsListener} to be used by the created
+     * {@link AccessTokens} implementation for reporting execution times.
      *
-     * @param metricsListener  The {@link MetricsListener} implementation to be used. See
-     *                         {@link DebugLogMetricsListener} for a potential implementation of
-     *                         this interface.
-     * @return The same {@link AccessTokensBuilder} instance this method has been called upon with
-     * the supplied {@link MetricsListener} set.
+     * @param metricsListener
+     *            The {@link MetricsListener} implementation to be used. See
+     *            {@link DebugLogMetricsListener} for a potential implementation
+     *            of this interface.
+     * @return The same {@link AccessTokensBuilder} instance this method has
+     *         been called upon with the supplied {@link MetricsListener} set.
      */
     public AccessTokensBuilder metricsListener(MetricsListener metricsListener) {
         checkLock();
@@ -439,7 +492,7 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     @Override
     public ScheduledExecutorService getExecutorService() {
         if (executorService == null) {
-            return Executors.newSingleThreadScheduledExecutor();
+            return Executors.newSingleThreadScheduledExecutor(new TokenRefresherThreadFactory());
         } else {
             return executorService;
         }
@@ -465,26 +518,29 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     }
 
     /**
-     * Create the {@link AccessTokens} instance along with any required additional components. After
-     * this method has been invoked this {@link AccessTokensBuilder} is in locked state and all
-     * further invocations of any of the configuration methods will throw an
+     * Create the {@link AccessTokens} instance along with any required
+     * additional components. After this method has been invoked this
+     * {@link AccessTokensBuilder} is in locked state and all further
+     * invocations of any of the configuration methods will throw an
      * {@link IllegalStateException}.
      *
-     * Invoking this method will create and start instances of {@link AccessTokenRefresher} as well
-     * as {@link AccessTokenRefresher} as configured previously using the
-     * {@link ScheduledExecutorService} as configured.
+     * Invoking this method will create and start instances of
+     * {@link AccessTokenRefresher} as well as {@link AccessTokenRefresher} as
+     * configured previously using the {@link ScheduledExecutorService} as
+     * configured.
      *
-     * In case no {@link ClientCredentialsProvider} has been configured an instance of
-     * {@link JsonFileBackedClientCredentialsProvider} is used.
+     * In case no {@link ClientCredentialsProvider} has been configured an
+     * instance of {@link JsonFileBackedClientCredentialsProvider} is used.
      *
-     * In case no {@link UserCredentialsProvider} has been configured an instance of
-     * {@link JsonFileBackedUserCredentialsProvider} is used.
+     * In case no {@link UserCredentialsProvider} has been configured an
+     * instance of {@link JsonFileBackedUserCredentialsProvider} is used.
      *
      * In case no {@link HttpProviderFactory} has been configured an instance of
      * {@link ClosableHttpProviderFactory} is used.
      *
-     * @return The {@link AccessTokens} instance built from the previously supplied configuration.
-     * Use it to e.g. get an {@link AccessToken} for any of your configured <i>tokenIds</i>.
+     * @return The {@link AccessTokens} instance built from the previously
+     *         supplied configuration. Use it to e.g. get an {@link AccessToken}
+     *         for any of your configured <i>tokenIds</i>.
      */
     public AccessTokens start() {
         if (accessTokenConfigurations.size() == 0) {
@@ -551,5 +607,4 @@ public class AccessTokensBuilder implements TokenRefresherConfiguration {
     public TimeUnit getTokenVerifierSchedulingTimeUnit() {
         return tokenVerifierSchedulingTimeUnit;
     }
-
 }

--- a/src/main/java/org/zalando/stups/tokens/TokenRefresherThreadFactory.java
+++ b/src/main/java/org/zalando/stups/tokens/TokenRefresherThreadFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.zalando.stups.tokens;
 
 import java.util.concurrent.ScheduledExecutorService;

--- a/src/main/java/org/zalando/stups/tokens/TokenRefresherThreadFactory.java
+++ b/src/main/java/org/zalando/stups/tokens/TokenRefresherThreadFactory.java
@@ -1,0 +1,32 @@
+package org.zalando.stups.tokens;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Custom-{@link ThreadFactory} to be used by the
+ * {@link ScheduledExecutorService} for {@link AccessTokenRefresher}.
+ *
+ */
+public final class TokenRefresherThreadFactory implements ThreadFactory {
+    private static final String THREAD_NAME_PREFIX = "token-refresher-";
+    private final AtomicInteger counter = new AtomicInteger(0);
+    private final boolean createDaemons;
+
+    public TokenRefresherThreadFactory(boolean createDaemons) {
+        this.createDaemons = createDaemons;
+    }
+
+    public TokenRefresherThreadFactory() {
+        this(true);
+    }
+
+    @Override
+    public Thread newThread(Runnable r) {
+        Thread t = new Thread(r, THREAD_NAME_PREFIX + counter.incrementAndGet());
+        t.setDaemon(createDaemons);
+        return t;
+    }
+
+}

--- a/src/test/java/org/zalando/stups/tokens/TokenRefresherThreadFactoryTest.java
+++ b/src/test/java/org/zalando/stups/tokens/TokenRefresherThreadFactoryTest.java
@@ -1,0 +1,68 @@
+package org.zalando.stups.tokens;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class TokenRefresherThreadFactoryTest {
+
+    @Test
+    public void testDaemonThreads() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(2);
+        ScheduledExecutorService es = Executors.newScheduledThreadPool(1, new TokenRefresherThreadFactory(true));
+        es.scheduleWithFixedDelay(new AssertionsRunnable(latch, new Expected("token-refresher-", true)), 1, 1,
+                TimeUnit.SECONDS);
+        latch.await();
+    }
+
+    @Test
+    public void testDaemonThreadsByDefault() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(2);
+        ScheduledExecutorService es = Executors.newScheduledThreadPool(1, new TokenRefresherThreadFactory());
+        es.scheduleWithFixedDelay(new AssertionsRunnable(latch, new Expected("token-refresher-", true)), 1, 1,
+                TimeUnit.SECONDS);
+        latch.await();
+    }
+
+    @Test
+    public void testNonDaemonThreads() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(2);
+        ScheduledExecutorService es = Executors.newScheduledThreadPool(1, new TokenRefresherThreadFactory(false));
+        es.scheduleWithFixedDelay(new AssertionsRunnable(latch, new Expected("token-refresher-", false)), 1, 1,
+                TimeUnit.SECONDS);
+        latch.await();
+    }
+
+    static class Expected {
+        private final String prefix;
+        private final boolean daemon;
+
+        public Expected(String prefix, boolean daemon) {
+            this.prefix = prefix;
+            this.daemon = daemon;
+        }
+    }
+
+    static class AssertionsRunnable implements Runnable {
+
+        private final CountDownLatch latch;
+        private final Expected expected;
+
+        public AssertionsRunnable(CountDownLatch latch, Expected expected) {
+            this.latch = latch;
+            this.expected = expected;
+        }
+
+        @Override
+        public void run() {
+            Assertions.assertThat(Thread.currentThread().getName().startsWith(expected.prefix));
+            Assertions.assertThat(Thread.currentThread().isDaemon()).isEqualTo(expected.daemon);
+            latch.countDown();
+        }
+
+    }
+}

--- a/src/test/java/org/zalando/stups/tokens/TokenRefresherThreadFactoryTest.java
+++ b/src/test/java/org/zalando/stups/tokens/TokenRefresherThreadFactoryTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.zalando.stups.tokens;
 
 import java.util.concurrent.CountDownLatch;


### PR DESCRIPTION
fixes #65 

The 'ScheduledExecutorService' is now created with a custom-'ThreadFactory' that will create 'daemon' threads by default, if the executor is not provided by the user.