### PR TITLE
Add support to create AccessTokensBuilder based on OAUTH2_ACCESS_TOKEN_URL

### DIFF
--- a/src/main/java/org/zalando/stups/tokens/Tokens.java
+++ b/src/main/java/org/zalando/stups/tokens/Tokens.java
@@ -18,11 +18,16 @@ package org.zalando.stups.tokens;
 import static org.zalando.stups.tokens.util.Objects.notNull;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 
 /**
  * Use e.g. {@link Tokens#createAccessTokensWithUri(URI)} to create an {@link AccessTokensBuilder}
  * which can be used to define multiple access tokens via {@link AccessTokensBuilder#manageToken(Object)}
  * that are managed and refreshed.
+ *
+ * If your environment exposes the URI for the access token endpoint
+ * via the <b>OAUTH2_ACCESS_TOKEN_URL</b> variable you can use {@link Tokens#createAccessTokens()}
+ * which will pick up the URI from there.
  */
 public final class Tokens {
     private Tokens() {
@@ -41,5 +46,28 @@ public final class Tokens {
      */
     public static AccessTokensBuilder createAccessTokensWithUri(final URI accessTokenUri) {
         return new AccessTokensBuilder(notNull("accessTokenUri", accessTokenUri));
+    }
+
+    /**
+     * Create a new {@link AccessTokensBuilder} which can be used to define multiple <i>tokenId</i>s
+     * which can be used to retrieved access tokens from the supplied <i>accessTokenUri</i> which
+     * may have e.g. different <i>scopes</i>. It will read the <i>accessTokenUri</i> from an
+     * environment variable named <b>OAUTH2_ACCESS_TOKEN_URL</b>.
+     *
+     * @return An {@link AccessTokensBuilder} which may be used to configure multiple <i>tokenIds</i>s
+     * with various <i>scopes</i> that are managed and refreshed automatically.
+     */
+    public static AccessTokensBuilder createAccessTokens() {
+        final String accessTokenUriString = System.getenv("OAUTH2_ACCESS_TOKEN_URL");
+        if (accessTokenUriString == null) {
+            throw new IllegalStateException("environment variable OAUTH2_ACCESS_TOKEN_URL not set");
+        }
+        final URI accessTokenUri;
+        try {
+            accessTokenUri = new URI(accessTokenUriString);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("environment variable OAUTH2_ACCESS_TOKEN_URL cannot be converted to an URI");
+        }
+        return createAccessTokensWithUri(accessTokenUri);
     }
 }


### PR DESCRIPTION
This will fix #45 and allow to create an `AccessTokensBuilder` without explicitly specifying the `accessTokenUri` in case your environment provides this URI via the `OAUTH2_ACCESS_TOKEN_URL` variable.

@jbellmann, @lmineiro and @hjacobs you might want to have a look.