### PR TITLE
GH #47: Proposal how to avoid exception logging.

### DIFF
--- a/src/main/java/org/zalando/stups/tokens/FileSupplier.java
+++ b/src/main/java/org/zalando/stups/tokens/FileSupplier.java
@@ -15,9 +15,10 @@
  */
 package org.zalando.stups.tokens;
 
-import java.io.File;
-
 import org.apache.http.util.Args;
+
+import java.io.File;
+import java.util.Optional;
 
 /**
  * Replacement to make it compatible with Java7.
@@ -48,17 +49,16 @@ public class FileSupplier {
     }
 
     public static File getCredentialsDir() {
-        String dir = System.getenv("CREDENTIALS_DIR");
-        if (dir == null) {
+        return credentialsDir()
+                .map(File::new)
+                .orElseThrow(() -> new IllegalStateException(
+                        "environment variable or application property CREDENTIALS_DIR not set"
+                ));
+    }
 
-            // this for testing
-            dir = System.getProperty("CREDENTIALS_DIR");
-            if (dir == null) {
-                throw new IllegalStateException("environment variable CREDENTIALS_DIR not set");
-            }
-        }
-
-        return new File(dir);
+    public static Optional<String> credentialsDir() {
+        Optional<String> optionalDir = Optional.ofNullable(System.getenv("CREDENTIALS_DIR"));
+        return optionalDir.isPresent() ? optionalDir : Optional.ofNullable(System.getProperty("CREDENTIALS_DIR"));
     }
 
 }

--- a/src/test/java/org/zalando/stups/tokens/AccessTokenBuilderTest.java
+++ b/src/test/java/org/zalando/stups/tokens/AccessTokenBuilderTest.java
@@ -15,13 +15,6 @@
  */
 package org.zalando.stups.tokens;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.util.concurrent.ScheduledExecutorService;
-
 import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
@@ -31,6 +24,14 @@ import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 import org.mockito.internal.util.io.IOUtil;
+import org.zalando.stups.tokens.fs.FilesystemSecretRefresher;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * 
@@ -119,7 +120,7 @@ public class AccessTokenBuilderTest {
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void accessTokenConfigurationWithouScopesShouldFail() {
+	public void accessTokenConfigurationWithoutScopesShouldFail() {
 		Tokens.createAccessTokensWithUri(uri).start();
 	}
 
@@ -167,4 +168,14 @@ public class AccessTokenBuilderTest {
         Assertions.assertThat(builder).isNotNull();
     }
 
+	@Test
+	public void checkCorrectRefresherUsed() throws Exception {
+		environmentVariables.set("OAUTH2_ACCESS_TOKEN_URL", "https://somwhere.test/tokens");
+		AccessTokensBuilder builder = Tokens.createAccessTokens();
+		AbstractAccessTokenRefresher refresher = builder.getAccessTokenRefresher();
+		assertThat(refresher instanceof FilesystemSecretRefresher);
+
+		System.getProperties().remove(CREDENTIALS_DIR);
+		assertThat(refresher instanceof AccessTokenRefresher);
+	}
 }

--- a/src/test/java/org/zalando/stups/tokens/FileSupplierTest.java
+++ b/src/test/java/org/zalando/stups/tokens/FileSupplierTest.java
@@ -15,13 +15,13 @@
  */
 package org.zalando.stups.tokens;
 
-import java.io.File;
-
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
 
 /**
  * @author  jbellmann
@@ -70,19 +70,16 @@ public class FileSupplierTest {
         supplier.get();
     }
 
-    @Test
+    @Test(expected = IllegalStateException.class)
     public void testNoCredentialsDirSet() {
         if (System.getenv("CREDENTIALS_DIR") != null) {
             LOG.warn("ENV 'CREDENTIALS_DIR' was set so we skip");
             return;
         }
-        try {
-            FileSupplier supplier = new FileSupplier("notExistent");
-            Assert.assertNotNull(supplier);
-            supplier.get();
-            Assertions.fail("expect an exception, when 'CREDENTIALS_DIR' not set in environment");
-        } catch (IllegalStateException t) {
-        }
+        FileSupplier supplier = new FileSupplier("notExistent");
+        Assert.assertNotNull(supplier);
+        supplier.get();
+        Assertions.fail("expect an exception, when 'CREDENTIALS_DIR' not set in environment");
     }
 
 }


### PR DESCRIPTION
Fix for #47. 

- Added additional check if property or ENV variable`CREDENTIALS_DIR` exists or not without throwing exception.
- `AccessTokensBuilder` code refactored. Now exception is not thrown during build if there is no `CREDENTIALS_DIR`.
- Added test for testing that `AccessTokensBuilder` receives correct `AbstractAccessTokenRefresher`