### PR TITLE
Remove coveralls

### DIFF
--- a/.github/workflows/build-with-maven.yml
+++ b/.github/workflows/build-with-maven.yml
@@ -23,7 +23,8 @@ jobs:
       with:
         java-version: 1.8
     - name: Build with Maven
-      env:
-        COVERALLS_REPO_TOKEN : ${{ secrets.COVERALLS_REPO_TOKEN }}
-      run: mvn -B install coveralls:report -Pgithub-actions
+      run: mvn -B install
     - uses: codecov/codecov-action@v1
+      with:
+        files: ./target/site/jacoco/jacoco.xml
+        flags: unittests

--- a/pom.xml
+++ b/pom.xml
@@ -204,29 +204,8 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.eluder.coveralls</groupId>
-                <artifactId>coveralls-maven-plugin</artifactId>
-                <version>4.3.0</version>
-                <configuration>
-                    <dryRun>${coveralls.dryRun}</dryRun>
-                    <repoToken>${env.COVERALLS_REPO_TOKEN}</repoToken>
-                    <jacocoReports>
-                        <jacocoReport>target/site/jacoco/jacoco.xml</jacocoReport>
-                    </jacocoReports>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>github-actions</id>
-            <properties>
-                <coveralls.dryRun>false</coveralls.dryRun>
-            </properties>
-        </profile>
-    </profiles>
 
     <distributionManagement>
         <snapshotRepository>


### PR DESCRIPTION
Remove `coveralls` integration because it does the same as codecov. Also it doesn't work with Github Actions in case of builds from a forked repos (see [this PR](https://github.com/coverallsapp/github-action/issues/30)) because the secrets can not be shared with builds from forks (Github limitation).

Fixes #242 