### PR TITLE
Updates log4j to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <coveralls.dryRun>true</coveralls.dryRun>
         <main.basedir>${basedir}</main.basedir>
 
-        <log4j2.version>2.14.1</log4j2.version>
+        <log4j2.version>2.15.0</log4j2.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
Mitigation for CVE-2021-44228 / Log4Shell vulnerability

Signed-off-by: Oliver <oliver.trosien@zalando.de>